### PR TITLE
Remove false hint about auto-launch from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Application supports Windows 7, 8, 8.1, 10 and Linux (in experimental stage).
 * Grab latest [release](../../releases/latest) for your platform.
 * Extract archive to your preferable folder.
 * Launch `openvr_widgets` binary.
-* Optional: Enable auto-launch in SteamVR settings.
 
 # Settings
 Editing `settings.xml` allows to make few own changes to widgets.  


### PR DESCRIPTION
The README is currently hinting that you could enable auto-launch in the startup overlay apps settings. This is false though at the moment, as openvr_widgets is not registering an application manifest which would allow that.

I did have a look at how different applications do that, but I couldn't figure out exactly on how to get this ported into this codebase. The code I was looking at for reference was this one, by the way:

https://github.com/matzman666/OpenVR-InputEmulator/blob/master/client_overlay/src/main.cpp#L51-L95